### PR TITLE
Update default_verifications.yml

### DIFF
--- a/default_verifications.yml
+++ b/default_verifications.yml
@@ -78,7 +78,7 @@
   MetricName:        EpochAttestationPerformance
   AggregateFunction: Average
   PassCriteria:      MinimumValue
-  PassValue:         95
+  PassValue:         85
 
 - VerificationName:  Post-Merge Epoch Target Attestation Performance
   ClientLayer:       Beacon
@@ -86,7 +86,7 @@
   MetricName:        EpochTargetAttestationPerformance
   AggregateFunction: Average
   PassCriteria:      MinimumValue
-  PassValue:         95
+  PassValue:         85
 
 - VerificationName:  Post-Merge Sync Participation Percentage
   ClientLayer:       Beacon
@@ -94,4 +94,4 @@
   MetricName:        SyncParticipationPercentage
   AggregateFunction: Average
   PassCriteria:      MinimumValue
-  PassValue:         95
+  PassValue:         85


### PR DESCRIPTION
Some client devs fear that the previous defaults may have been too tight for local, small testnets. Loosing up the restrictions in order to make it a bit easier for the CI to pass. 